### PR TITLE
Adding default protocol to URL inputs

### DIFF
--- a/app/index.py
+++ b/app/index.py
@@ -12,10 +12,15 @@ def bypass_paywall(url):
     """
     Bypass paywall for a given url
     """
-    response = requests.get(url, headers=googlebot_headers)
-    response.encoding = response.apparent_encoding
-    return response.text
-
+    if url.startswith("http"):
+        response = requests.get(url, headers=googlebot_headers)
+        response.encoding = response.apparent_encoding
+        return response.text
+    
+    try:
+        return bypass_paywall("https://" + url)
+    except requests.exceptions.RequestException as e:
+        return bypass_paywall("http://" + url)
 
 @app.route("/")
 def main_page():


### PR DESCRIPTION
## 📑 Description
Currently, when a user enters a URL without specifying a protocol (e.g., just "google.com") in the index page input field, the application returns an error message stating that "No scheme was provided." To help users avoid such errors, I propose adding a default protocol (HTTPS or HTTP) to their input. If the entered URL already includes a protocol, it will leave it unchanged.