### PR TITLE
Use correct command for `docker compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ It pretends to be GoogleBot (Google's web crawler) and gets the same content tha
 
 Requirements:
 - docker
-- docker-compose
+- Docker Compose (available as `docker compose`)
+
 First, clone the repo to your machine then run the following commands:
 
 ```sh
 git clone https://github.com/wasi-master/13ft.git
 cd 13ft
-docker-compose up
+docker compose up
 ```
 
 The image is also available from [DockerHub](https://hub.docker.com/r/wasimaster/13ft "docker pull wasimaster/13ft") or [ghcr.io](https://github.com/wasi-master/13ft/pkgs/container/13ft "docker pull ghcr.io/wasi-master/13ft:0.2.3") so the command `docker pull wasimaster/13ft` also works.


### PR DESCRIPTION
`docker-compose` (V1) has been deprecated since July 2023, and Compose V2 is its replacement. Since V2 was announced, it was always available as `docker compose` rather than the single command `docker-compose`. Modern installations of Docker no longer even ship with `docker-compose` itself.

---

## 📑 Context

See Docker's page titled ["Migrate to Compose V2"](https://docs.docker.com/compose/migrate/) which explains that the **single command** `docker-compose` with a hyphen was part of V1 and is now deprecated. Users should instead use `docker compose`, and the page mentions that this process started a while back:

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

I can confirm that I was unable to follow the `README` to start 13ft, since `docker-compose` is **not available** on my machine:
```shell
$ docker-compose
zsh: command not found: docker-compose
```

## ✅ Checks
- [X] I was able to run the service using `docker compose up` just as expected.

## ℹ Additional Information

A possible improvement here would be to _also_ mention `docker-compose` as a fallback if anyone is running a very old version of Docker, but then you'd have to decide also how long to keep this mention in the `README` for… overall this doesn't really seem worth it. `docker-compose` has been deprecated for a while and is well on its way out.

The new line added after the list is to make sure it doesn't bring the one right after next to it. See [this demo without the new line](https://github.com/nicolasff/13ft-fork/tree/12819dbf023542bb8392cd21481716ddadad5b56?tab=readme-ov-file#using-docker) and notice how there's a **single line** reading "Docker Compose (available as `docker compose`) First, clone the repo to your machine then run the following commands:" – instead of two, as intended.