### PR TITLE
Use production-ready Gunicorn WSGI server instead of Flask dev server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY . .
 RUN pip install -r requirements.txt
 WORKDIR /app
 EXPOSE 5000
-ENTRYPOINT [ "python" ]
-CMD [ "portable.py" ] 
+ENTRYPOINT [ "gunicorn" ]
+CMD [  "portable:app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
+# syntax=docker/dockerfile:1
 FROM python:3.13.7-alpine
+
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup -g $GID thirteener
+RUN adduser -D -g '' -u $UID -G thirteener thirteener
 
 # Generic labels
 LABEL maintainer="Arian Mollik Wasi <arianmollik323@gmail.com>"
@@ -18,9 +25,13 @@ LABEL org.opencontainers.image.description="My own custom 12ft.io replacement"
 LABEL org.opencontainers.image.documentation="https://github.com/wasi-master/13ft/blob/main/README.md"
 LABEL org.opencontainers.image.licenses=MIT
 
+RUN python -m pip install --upgrade pip
+
+USER thirteener
 COPY . .
-RUN pip install -r requirements.txt
+RUN --mount=type=cache,mode=0755,target=/home/thirteener/.cache/pip \
+  pip install -U -r requirements.txt
+
 WORKDIR /app
 EXPOSE 5000
-ENTRYPOINT [ "gunicorn" ]
-CMD [  "portable:app" ]
+CMD [ "python", "-m", "gunicorn", "portable:app" ]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It pretends to be GoogleBot (Google's web crawler) and gets the same content tha
 ### Using Docker
 
 Requirements:
+
 - docker
 - Docker Compose (available as `docker compose`)
 
@@ -44,7 +45,7 @@ If that doesn't work retry but replace `python` with `py`, then try `python3`, t
 Then run `portable.py`, click [this link](https://realpython.com/run-python-scripts/) for a tutorial on how to run python scripts.
 
 ```sh
-python portable.py
+python -m gunicorn 'portable:app'
 ```
 
 Then open the link shown in the terminal in the browser and you'll be able to use this
@@ -58,26 +59,29 @@ python -m pip install -r requirements.txt
 FLASK_APP=app/portable.py flask run --host=127.0.0.1 --port=9982
 ```
 
-
 ## Using as a Bookmarklet in Chrome:
 
 You can create a bookmarklet that performs the URL transformation by writing a small JavaScript snippet. Below is the JavaScript code for your bookmarklet:
+
 ```javascript
-javascript:(function(){window.location.href='https://13ft.wasimaster.me/'+encodeURIComponent(window.location.href);})();
+javascript: (function () {
+  window.location.href =
+    "https://13ft.wasimaster.me/" + encodeURIComponent(window.location.href);
+})();
 ```
+
 You can replace https://13ft.wasimaster.me with your own 13ft instance if desired.
 
 Steps:
+
 1. Open Bookmarks Manager:
 
 2. Click on the three dots (menu) in the top-right corner of Chrome.
-Go to Bookmarks > Bookmark manager, or simply press Ctrl+Shift+O on Windows/Linux or Cmd+Option+B on Mac.
-Create a New Bookmark:
+   Go to Bookmarks > Bookmark manager, or simply press Ctrl+Shift+O on Windows/Linux or Cmd+Option+B on Mac.
+   Create a New Bookmark:
 
 3. In the Bookmark Manager, click the three-dot menu in the top-right corner of the window and select Add new bookmark.
-Enter Bookmark Details:
-    - Name: Enter a name for your bookmarklet, such as "13ft-ize". This name will show as a bookmark title in the bookmarks bar
-    - URL: Paste the JavaScript code provided above into the URL field.
+   Enter Bookmark Details: - Name: Enter a name for your bookmarklet, such as "13ft-ize". This name will show as a bookmark title in the bookmarks bar - URL: Paste the JavaScript code provided above into the URL field.
 4. Click Save.
 
 Using the Bookmarklet:

--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -1,0 +1,4 @@
+from os import environ
+
+# https://docs.gunicorn.org/en/stable/settings.html#settings
+bind = f"0.0.0.0:{environ.get('PORT', 5000)}"

--- a/app/index.py
+++ b/app/index.py
@@ -1,35 +1,38 @@
+from urllib.parse import urljoin, urlparse
+
 import flask
 import requests
-from flask import request
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse, urljoin
+from flask import request
 
 app = flask.Flask(__name__)
 googlebot_headers = {
     "User-Agent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.6533.119 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 }
 
+
 def add_base_tag(html_content, original_url):
-    soup = BeautifulSoup(html_content, 'html.parser')
+    soup = BeautifulSoup(html_content, "html.parser")
     parsed_url = urlparse(original_url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}/"
-    
+
     # Handle paths that are not root, e.g., "https://x.com/some/path/w.html"
-    if parsed_url.path and not parsed_url.path.endswith('/'):
-        base_url = urljoin(base_url, parsed_url.path.rsplit('/', 1)[0] + '/')
-    base_tag = soup.find('base')
-    
+    if parsed_url.path and not parsed_url.path.endswith("/"):
+        base_url = urljoin(base_url, parsed_url.path.rsplit("/", 1)[0] + "/")
+    base_tag = soup.find("base")
+
     print(base_url)
     if not base_tag:
-        new_base_tag = soup.new_tag('base', href=base_url)
+        new_base_tag = soup.new_tag("base", href=base_url)
         if soup.head:
             soup.head.insert(0, new_base_tag)
         else:
-            head_tag = soup.new_tag('head')
+            head_tag = soup.new_tag("head")
             head_tag.insert(0, new_base_tag)
             soup.insert(0, head_tag)
-    
+
     return str(soup)
+
 
 def bypass_paywall(url):
     """

--- a/app/portable.py
+++ b/app/portable.py
@@ -260,4 +260,5 @@ def get_article(path):
         return "Invalid URL", 400
 
 
-app.run(host="0.0.0.0", port=5000, debug=False)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=False)

--- a/app/portable.py
+++ b/app/portable.py
@@ -1,8 +1,9 @@
+from urllib.parse import urljoin, urlparse
+
 import flask
 import requests
-from flask import request
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse, urljoin
+from flask import request
 
 app = flask.Flask(__name__)
 googlebot_headers = {
@@ -187,27 +188,29 @@ html = """
 </html>
 """
 
+
 def add_base_tag(html_content, original_url):
-    soup = BeautifulSoup(html_content, 'html.parser')
+    soup = BeautifulSoup(html_content, "html.parser")
     parsed_url = urlparse(original_url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}/"
-    
+
     # Handle paths that are not root, e.g., "https://x.com/some/path/w.html"
-    if parsed_url.path and not parsed_url.path.endswith('/'):
-        base_url = urljoin(base_url, parsed_url.path.rsplit('/', 1)[0] + '/')
-    base_tag = soup.find('base')
-    
+    if parsed_url.path and not parsed_url.path.endswith("/"):
+        base_url = urljoin(base_url, parsed_url.path.rsplit("/", 1)[0] + "/")
+    base_tag = soup.find("base")
+
     print(base_url)
     if not base_tag:
-        new_base_tag = soup.new_tag('base', href=base_url)
+        new_base_tag = soup.new_tag("base", href=base_url)
         if soup.head:
             soup.head.insert(0, new_base_tag)
         else:
-            head_tag = soup.new_tag('head')
+            head_tag = soup.new_tag("head")
             head_tag.insert(0, new_base_tag)
             soup.insert(0, head_tag)
-    
+
     return str(soup)
+
 
 def bypass_paywall(url):
     """

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
-flask
-requests
 bs4
+flask
+gunicorn
+requests

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,9 @@
+services:
+  13ft:
+    container_name: 13ft
+    hostname: 13ft
+    build:
+      context: .
+    restart: unless-stopped
+    ports:
+      - "5000:5000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-flask
-requests
 bs4
+flask
+gunicorn
+requests


### PR DESCRIPTION
Closes #40 

## 📑 Description
Replaces the [Flask development server](https://github.com/wasi-master/13ft/blob/52a8f8b32f52cb6fd75d9fece088337a720f8a17/app/portable.py#L260) with a production-ready Gunicorn server. I configured the Gunicorn port to be the same `5000` as before, but it is also configurable via the `PORT` environment variable like [PR #18](https://github.com/wasi-master/13ft/pull/18). I also updated the Dockerfile to run the Gunicorn server as a rootless user per [Flask docs](https://flask.palletsprojects.com/en/stable/deploying/gunicorn/#binding-externally).

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
- [x] Production WSGI server
  - Done with [Gunicorn](https://docs.gunicorn.org/en/stable/index.html)
- [ ] [Reverse Proxy Config](https://flask.palletsprojects.com/en/stable/deploying/proxy_fix/)
  - The `ProxyFix` class config is dependent on the proxy setup of the end-user, so I need to figure out a way to easily configure this with sane defaults. Maybe it should just be its own PR?

## ✅ Checks
- [X] My code requires changes to the documentation
  - Just a slight change to README, already done
- [X] I have updated the documentation as required
- [X] All the tests have passed if any

## ℹ Additional Information
Three more changes that aren't necessary, but helpful imo:

- I added a compose file for development, `docker-compose.dev.yaml`. Use it like so: `docker compose -f docker-compose.dev.yaml <command>`
- I updated the Dockerfile to cache the pip dependencies so that they don't have to be re-downloaded every single time the image is built.
- I accidentally ran a markdown formatter on the README.

If either of these are an issue, I can easily undo them.